### PR TITLE
Correct URL to demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ It also supports drag and drop to re arrange tasks in the list
 # Demo site
 See for demo and instruction for isntalling the plugin
 
- https://github.com/kookma/TW-Todolist
+https://kookma.github.io/TW-Todolist/


### PR DESCRIPTION
The "demo site" link led to the Git repository instead of the demo site.